### PR TITLE
Duo/tp update

### DIFF
--- a/tpv105/generating_the_mesh.sh
+++ b/tpv105/generating_the_mesh.sh
@@ -3,7 +3,7 @@
 prefix=tpv105_half
 # Generate half a mesh using gmsh
 #for gmsh, see http://gmsh.info/#Download
-gmsh -3 $prefix.geo
+gmsh -3 $prefix.geo -format msh2
 
 # Convert the mesh from neu to hdf5 using pumgen
 # for pumgen, see https://github.com/SeisSol/PUMGen/wiki/How-to-compile-PUMGen

--- a/tpv5/tpv5_f200m.geo
+++ b/tpv5/tpv5_f200m.geo
@@ -48,15 +48,15 @@ gmsh2gambit -i planar-anydip.msh -o planar-anydip.neu
 lc = 25e3;
 lc_fault = 200;
 
-Fault_length = 30e3;
-Fault_width = 15e3;
+Fault_length = 44e3;
+Fault_width = 22e3;
 Fault_dip = 90*Pi/180.;
 
 //Nucleation in X,Z local coordinates
 X_nucl = 0e3;
 Width_nucl = 0.5*Fault_width;
 R_nucl = 1.5e3;
-lc_nucl = 300;
+lc_nucl = 200;
 
 Xmax = 60e3;
 Xmin = -Xmax;


### PR DESCRIPTION
Hi, add -format msh2 in gmsh otherwise pumgen doesn't work. 
I also found an issue in mirrorMesh.py
Traceback (most recent call last):
  File "../../Meshing/mirrorMesh/mirrorMesh.py", line 59, in <module>
    sx = seissolxdmf.seissolxdmf(args.filename)
  File "/import/deadlock-data/dli/easi_2019-5/Visualization/seissolxmdf/seissolxdmf/seissolxdmf.py", line 11, in __init__
    self.nElements = self.ReadNElements()
  File "/import/deadlock-data/dli/easi_2019-5/Visualization/seissolxmdf/seissolxdmf/seissolxdmf.py", line 169, in ReadNElements
    raise NameError("nElements could not be determined")

My xdmf is like this:

<?xml version="1.0" ?>
<!DOCTYPE Xdmf SYSTEM "Xdmf.dtd" []>
<Xdmf Version="2.0">
 <Domain>
  <Grid Name="puml mesh" GridType="Uniform">
   <Topology TopologyType="Tetrahedron" NumberOfElements="756342">
    <DataItem NumberType="Int" Precision="8" Format="HDF" Dimensions="756342 4">tpv105_half.puml.h5:/connect</DataItem>
   </Topology>
   <Geometry name="geo" GeometryType="XYZ" NumberOfElements="143160">
    <DataItem NumberType="Float" Precision="8" Format="HDF" Dimensions="143160 3">tpv105_half.puml.h5:/geometry</DataItem>
   </Geometry>
   <Attribute Name="group" Center="Cell">
    <DataItem  NumberType="Int" Precision="4" Format="HDF" Dimensions="756342">tpv105_half.puml.h5:/group</DataItem>
   </Attribute>
   <Attribute Name="boundary" Center="Cell">
    <DataItem NumberType="Int" Precision="4" Format="HDF" Dimensions="756342">tpv105_half.puml.h5:/boundary</DataItem>
   </Attribute>
  </Grid>
 </Domain>
</Xdmf>

