### PR TITLE
Thomas/update fl2

### DIFF
--- a/Northridge/parameters.par
+++ b/Northridge/parameters.par
@@ -1,6 +1,8 @@
 &equations
 !yaml file defining spatial dependance of material properties
 MaterialFileName = 'northridge_material.yaml'
+FreqCentral=0.3
+FreqRatio=100
 /
 
 &IniCondition
@@ -28,7 +30,6 @@ meshgenerator = 'PUML'                         ! Name of meshgenerator (Gambit3D
 
 &Discretization
 CFL = 0.5                                      ! CFL number (<=1.0)
-FixTimeStep = 5                                ! Manualy chosen minimum time
 ClusteredLTS = 2                               ! 1 for Global time stepping, 2,3,5,... Local time stepping (advised value 2)
 !ClusteredLTS defines the multi-rate for the time steps of the clusters 2 for Local time stepping
 /

--- a/Northridge/parameters.par
+++ b/Northridge/parameters.par
@@ -59,6 +59,10 @@ RFileName = 'offreceivers.dat'       ! Record Points in extra file
 xdmfWriterBackend = 'posix' ! (optional) The backend used in fault, wavefield,
 ! and free-surface output. The HDF5 backend is only supported when SeisSol is compiled with
 ! HDF5 support.
+
+EnergyOutput = 1 ! Computation of energy, written in csv file
+EnergyTerminalOutput = 1 ! Write energy to standard output
+EnergyOutputInterval = 0.5
 /
 
 &AbortCriteria

--- a/Northridge_FL33/parameters.par
+++ b/Northridge_FL33/parameters.par
@@ -83,6 +83,10 @@ RFileName = 'offreceivers.dat'       ! Record Points in extra file
 xdmfWriterBackend = 'posix' ! (optional) The backend used in fault, wavefield,
 ! and free-surface output. The HDF5 backend is only supported when SeisSol is compiled with
 ! HDF5 support.
+
+EnergyOutput = 1 ! Computation of energy, written in csv file
+EnergyTerminalOutput = 1 ! Write energy to standard output
+EnergyOutputInterval = 0.5
 /
 
 &AbortCriteria

--- a/Northridge_FL33/parameters.par
+++ b/Northridge_FL33/parameters.par
@@ -25,8 +25,6 @@ ZRef = -1.0
 refPointMethod = 1
 
 RF_output_on = 0                               ! Rupture front ascii output
-magnitude_output_on =0                         ! Moment magnitude output
-energy_rate_output_on=0                        ! Moment rate output
 OutputPointType = 4                            ! Type (0: no output, 3: ascii file, 4: paraview file, 5: 3+4)
 SlipRateOutputType=0        ! 0: (smoother) slip rate output evaluated from the difference between the velocity on both side of the fault
                             ! 1: slip rate output evaluated from the fault tractions and the failure criterion (less smooth but usually more accurate where the rupture front is well developped)

--- a/tpv101/parameters101.par
+++ b/tpv101/parameters101.par
@@ -39,8 +39,6 @@ ZRef = 0.0
 refPointMethod = 1
 
 RF_output_on = 0                               ! Rupture front ascii output
-magnitude_output_on =0                         ! Moment magnitude output
-energy_rate_output_on =0                       ! Moment rate output
 OutputPointType = 5                            ! Type (0: no output, 3: ascii file, 4: paraview file, 5: 3+4)
 SlipRateOutputType=0        ! 0: (smoother) slip rate output evaluated from the difference between the velocity on both side of the fault
                             ! 1: slip rate output evaluated from the fault tractions and the failure criterion (less smooth but usually more accurate where the rupture front is well developped)

--- a/tpv101/parameters101.par
+++ b/tpv101/parameters101.par
@@ -109,6 +109,10 @@ printIntervalCriterion = 2          ! Criterion for index of printed info: 1=tim
 !xdmfWriterBackend = 'posix' ! (optional) The backend used in fault, wavefield,
 ! and free-surface output. The HDF5 backend is only supported when SeisSol is compiled with
 ! HDF5 support.
+
+EnergyOutput = 1 ! Computation of energy, written in csv file
+EnergyTerminalOutput = 1 ! Write energy to standard output
+EnergyOutputInterval = 0.5
 /
 
 &AbortCriteria

--- a/tpv104/parameters.par
+++ b/tpv104/parameters.par
@@ -90,10 +90,12 @@ FaultOutputFlag = 1                  ! DR output (add this line only if DR is ac
 RFileName = 'tpv104_receivers.dat'      ! Record Points in extra file
 !checkPointInterval = 1.5 ! Set to 0 to disable checkpointing
 !checkPointBackend = 'posix' ! Either ’hdf5’, ’mpio’ or ’none’
+
+EnergyOutput = 1 ! Computation of energy, written in csv file
+EnergyTerminalOutput = 1 ! Write energy to standard output
+EnergyOutputInterval = 0.5
 /
 
-/
-            
 &AbortCriteria
 EndTime = 10.0
 /
@@ -102,4 +104,4 @@ EndTime = 10.0
 /
 
 &Debugging
-
+/

--- a/tpv105/parameters.par
+++ b/tpv105/parameters.par
@@ -46,8 +46,6 @@ ZRef = 0.0
 refPointMethod = 1
 
 RF_output_on = 0                               ! Rupture front ascii output
-magnitude_output_on =0                         ! Moment magnitude output
-energy_rate_output_on =1                       ! Moment rate output
 OutputPointType = 5                            ! Type (0: no output, 3: ascii file, 4: paraview file, 5: 3+4)
 SlipRateOutputType=1        ! 0: (smoother) slip rate output evaluated from the difference between the velocity on both side of the fault
                             ! 1: slip rate output evaluated from the fault tractions and the failure criterion (less smooth but usually more accurate where the rupture front is well developped)

--- a/tpv105/parameters.par
+++ b/tpv105/parameters.par
@@ -116,6 +116,10 @@ printIntervalCriterion = 2          ! Criterion for index of printed info: 1=tim
 xdmfWriterBackend = 'posix' ! (optional) The backend used in fault, wavefield,
 ! and free-surface output. The HDF5 backend is only supported when SeisSol is compiled with
 ! HDF5 support.
+
+EnergyOutput = 1 ! Computation of energy, written in csv file
+EnergyTerminalOutput = 1 ! Write energy to standard output
+EnergyOutputInterval = 0.5
 /
 
 &AbortCriteria

--- a/tpv12_13/parameters.par
+++ b/tpv12_13/parameters.par
@@ -31,8 +31,6 @@ ZRef = 0.0
 refPointMethod = 1
 
 RF_output_on = 1                               ! Rupture front ascii output
-magnitude_output_on =0                         ! Moment magnitude output
-energy_rate_output_on =1                       ! Moment rate output
 OutputPointType = 5                            ! Type (0: no output, 3: ascii file, 4: paraview file, 5: 3+4)
 SlipRateOutputType=1        ! 0: (smoother) slip rate output evaluated from the difference between the velocity on both side of the fault
                             ! 1: slip rate output evaluated from the fault tractions and the failure criterion (less smooth but usually more accurate where the rupture front is well developped)

--- a/tpv12_13/parameters.par
+++ b/tpv12_13/parameters.par
@@ -97,6 +97,10 @@ RFileName = 'tpv12_13_receivers.dat'      ! Record Points in extra file
 xdmfWriterBackend = 'posix' ! (optional) The backend used in fault, wavefield,
 ! and free-surface output. The HDF5 backend is only supported when SeisSol is compiled with
 ! HDF5 support.
+
+EnergyOutput = 1 ! Computation of energy, written in csv file
+EnergyTerminalOutput = 1 ! Write energy to standard output
+EnergyOutputInterval = 0.5
 /
 
 &AbortCriteria

--- a/tpv12_13/tpv12_13_fault.yaml
+++ b/tpv12_13/tpv12_13_fault.yaml
@@ -21,3 +21,8 @@
         mu_d:        0.10
         d_c:         0.50
         cohesion: -200000
+[Tnuc_n, Tnuc_s, Tnuc_d]: !ConstantMap
+    map:
+        Tnuc_n: 0
+        Tnuc_s: 0
+        Tnuc_d: 0

--- a/tpv16/parameters.par
+++ b/tpv16/parameters.par
@@ -28,8 +28,6 @@ ZRef = 0.0
 refPointMethod = 1
 
 RF_output_on = 1                               ! Rupture front ascii output
-magnitude_output_on =0                         ! Moment magnitude output
-energy_rate_output_on =1                       ! Moment rate output
 OutputPointType = 5                            ! Type (0: no output, 3: ascii file, 4: paraview file, 5: 3+4)
 SlipRateOutputType=1        ! 0: (smoother) slip rate output evaluated from the difference between the velocity on both side of the fault
                             ! 1: slip rate output evaluated from the fault tractions and the failure criterion (less smooth but usually more accurate where the rupture front is well developped)

--- a/tpv16/parameters.par
+++ b/tpv16/parameters.par
@@ -94,6 +94,10 @@ RFileName = 'tpv16_receivers.dat'      ! Record Points in extra file
 xdmfWriterBackend = 'posix' ! (optional) The backend used in fault, wavefield,
 ! and free-surface output. The HDF5 backend is only supported when SeisSol is compiled with
 ! HDF5 support.
+
+EnergyOutput = 1 ! Computation of energy, written in csv file
+EnergyTerminalOutput = 1 ! Write energy to standard output
+EnergyOutputInterval = 0.5
 /
 
 &AbortCriteria

--- a/tpv24/parameters.par
+++ b/tpv24/parameters.par
@@ -94,6 +94,10 @@ RFileName = 'tpv24_receivers.dat'      ! Record Points in extra file
 xdmfWriterBackend = 'posix' ! (optional) The backend used in fault, wavefield,
 ! and free-surface output. The HDF5 backend is only supported when SeisSol is compiled with
 ! HDF5 support.
+
+EnergyOutput = 1 ! Computation of energy, written in csv file
+EnergyTerminalOutput = 1 ! Write energy to standard output
+EnergyOutputInterval = 0.5
 /
 
 &AbortCriteria

--- a/tpv24/parameters.par
+++ b/tpv24/parameters.par
@@ -28,8 +28,6 @@ ZRef = 0.0
 refPointMethod = 1
 
 RF_output_on = 1                               ! Rupture front ascii output
-magnitude_output_on =0                         ! Moment magnitude output
-energy_rate_output_on =1                       ! Moment rate output
 OutputPointType = 5                            ! Type (0: no output, 3: ascii file, 4: paraview file, 5: 3+4)
 SlipRateOutputType=1        ! 0: (smoother) slip rate output evaluated from the difference between the velocity on both side of the fault
                             ! 1: slip rate output evaluated from the fault tractions and the failure criterion (less smooth but usually more accurate where the rupture front is well developped)

--- a/tpv29/parameters.par
+++ b/tpv29/parameters.par
@@ -28,8 +28,6 @@ ZRef = 0.0
 refPointMethod = 1
 
 RF_output_on = 1                               ! Rupture front ascii output
-magnitude_output_on =0                         ! Moment magnitude output
-energy_rate_output_on =1                       ! Moment rate output
 OutputPointType = 5                            ! Type (0: no output, 3: ascii file, 4: paraview file, 5: 3+4)
 SlipRateOutputType=1        ! 0: (smoother) slip rate output evaluated from the difference between the velocity on both side of the fault
                             ! 1: slip rate output evaluated from the fault tractions and the failure criterion (less smooth but usually more accurate where the rupture front is well developped)

--- a/tpv29/parameters.par
+++ b/tpv29/parameters.par
@@ -94,6 +94,10 @@ RFileName = 'tpv29_receivers.dat'      ! Record Points in extra file
 xdmfWriterBackend = 'posix' ! (optional) The backend used in fault, wavefield,
 ! and free-surface output. The HDF5 backend is only supported when SeisSol is compiled with
 ! HDF5 support.
+
+EnergyOutput = 1 ! Computation of energy, written in csv file
+EnergyTerminalOutput = 1 ! Write energy to standard output
+EnergyOutputInterval = 0.5
 /
 
 &AbortCriteria

--- a/tpv33/parameters.par
+++ b/tpv33/parameters.par
@@ -92,6 +92,10 @@ RFileName = 'tpv33_receivers.dat'    ! Record Points in extra file
 xdmfWriterBackend = 'posix' ! (optional) The backend used in fault, wavefield,
 ! and free-surface output. The HDF5 backend is only supported when SeisSol is compiled with
 ! HDF5 support.
+
+EnergyOutput = 1 ! Computation of energy, written in csv file
+EnergyTerminalOutput = 1 ! Write energy to standard output
+EnergyOutputInterval = 0.5
 /
 
 &AbortCriteria

--- a/tpv33/parameters.par
+++ b/tpv33/parameters.par
@@ -26,8 +26,6 @@ ZRef = 0.0
 refPointMethod = 1
 
 RF_output_on = 1                               ! Rupture front ascii output
-magnitude_output_on =0                         ! Moment magnitude output
-energy_rate_output_on =1                       ! Moment rate output
 OutputPointType = 5                            ! Type (0: no output, 3: ascii file, 4: paraview file, 5: 3+4)
 SlipRateOutputType=1        ! 0: (smoother) slip rate output evaluated from the difference between the velocity on both side of the fault
                             ! 1: slip rate output evaluated from the fault tractions and the failure criterion (less smooth but usually more accurate where the rupture front is well developped)

--- a/tpv33/tpv33_fault.yaml
+++ b/tpv33/tpv33_fault.yaml
@@ -52,3 +52,8 @@
         return s_xy0 + s_xy1;
       s_yz:     return 0.0;
       s_xz:     return 0.0;
+[Tnuc_n, Tnuc_s, Tnuc_d]: !ConstantMap
+    map:
+        Tnuc_n: 0
+        Tnuc_s: 0
+        Tnuc_d: 0

--- a/tpv34/parameters.par
+++ b/tpv34/parameters.par
@@ -88,6 +88,10 @@ printIntervalCriterion = 2                     ! Criterion for index of printed 
 pickdt = 0.005                                 ! Pickpoint Sampling
 pickDtType = 1                                 ! Pickpoint Type
 RFileName = 'tpv34_receivers.dat'              ! Record Points in extra file
+
+EnergyOutput = 1 ! Computation of energy, written in csv file
+EnergyTerminalOutput = 1 ! Write energy to standard output
+EnergyOutputInterval = 0.5
 /
 
 &AbortCriteria

--- a/tpv34/parameters.par
+++ b/tpv34/parameters.par
@@ -26,8 +26,6 @@ ZRef = 0.0
 refPointMethod = 1
 
 RF_output_on = 1                               ! Rupture front ascii output
-magnitude_output_on = 0                        ! Moment magnitude output
-energy_rate_output_on = 0                      ! Moment rate output
 OutputPointType = 5                            ! Type (0: no output, 3: ascii file, 4: paraview file, 5: 3+4)
 SlipRateOutputType = 1      ! 0: (smoother) slip rate output evaluated from the difference between the velocity on both side of the fault
                             ! 1: slip rate output evaluated from the fault tractions and the failure criterion (less smooth but usually more accurate where the rupture front is well developped)

--- a/tpv34/tpv34_fault.yaml
+++ b/tpv34/tpv34_fault.yaml
@@ -47,3 +47,8 @@
         return s_xy0 + s_xy1;
       s_yz:     return 0.0;
       s_xz:     return 0.0;
+[Tnuc_n, Tnuc_s, Tnuc_d]: !ConstantMap
+    map:
+        Tnuc_n: 0
+        Tnuc_s: 0
+        Tnuc_d: 0

--- a/tpv5/fault.yaml
+++ b/tpv5/fault.yaml
@@ -36,3 +36,8 @@
      mu_d:        0.525
      d_c:         0.4
      cohesion:    0.0
+[Tnuc_n, Tnuc_s, Tnuc_d]: !ConstantMap
+    map:
+        Tnuc_n: 0
+        Tnuc_s: 0
+        Tnuc_d: 0

--- a/tpv5/parameters.par
+++ b/tpv5/parameters.par
@@ -92,6 +92,10 @@ RFileName = 'tpv5_receivers.dat'      ! Record Points in extra file
 xdmfWriterBackend = 'posix' ! (optional) The backend used in fault, wavefield,
 ! and free-surface output. The HDF5 backend is only supported when SeisSol is compiled with
 ! HDF5 support.
+
+EnergyOutput = 1 ! Computation of energy, written in csv file
+EnergyTerminalOutput = 1 ! Write energy to standard output
+EnergyOutputInterval = 0.5
 /
 
 &AbortCriteria

--- a/tpv5/parameters.par
+++ b/tpv5/parameters.par
@@ -26,8 +26,6 @@ ZRef = 0.0
 refPointMethod = 1
 
 RF_output_on = 1                               ! Rupture front ascii output
-magnitude_output_on =0                         ! Moment magnitude output
-energy_rate_output_on =1                       ! Moment rate output
 OutputPointType = 5                            ! Type (0: no output, 3: ascii file, 4: paraview file, 5: 3+4)
 SlipRateOutputType=1        ! 0: (smoother) slip rate output evaluated from the difference between the velocity on both side of the fault
                             ! 1: slip rate output evaluated from the fault tractions and the failure criterion (less smooth but usually more accurate where the rupture front is well developped)

--- a/tpv5/tpv5_f200m.geo
+++ b/tpv5/tpv5_f200m.geo
@@ -173,5 +173,6 @@ Physical Surface(103) = {100,200};
 //This ones are read in the gui
 Physical Surface(105) = {14,18,22,26,27};
 
+Mesh.Algorithm3D = 'HXT'
 Physical Volume(1) = {1};
 Mesh.MshFileVersion = 2.2;

--- a/tpv6_7/parameters.par
+++ b/tpv6_7/parameters.par
@@ -28,8 +28,6 @@ ZRef = 0.0
 refPointMethod = 1
 
 RF_output_on = 1                               ! Rupture front ascii output
-magnitude_output_on =0                         ! Moment magnitude output
-energy_rate_output_on =1                       ! Moment rate output
 OutputPointType = 5                            ! Type (0: no output, 3: ascii file, 4: paraview file, 5: 3+4)
 SlipRateOutputType=1        ! 0: (smoother) slip rate output evaluated from the difference between the velocity on both side of the fault
                             ! 1: slip rate output evaluated from the fault tractions and the failure criterion (less smooth but usually more accurate where the rupture front is well developped)

--- a/tpv6_7/parameters.par
+++ b/tpv6_7/parameters.par
@@ -94,6 +94,10 @@ RFileName = 'tpv6_receivers.dat'      ! Record Points in extra file
 xdmfWriterBackend = 'posix' ! (optional) The backend used in fault, wavefield,
 ! and free-surface output. The HDF5 backend is only supported when SeisSol is compiled with
 ! HDF5 support.
+
+EnergyOutput = 1 ! Computation of energy, written in csv file
+EnergyTerminalOutput = 1 ! Write energy to standard output
+EnergyOutputInterval = 0.5
 /
 
 &AbortCriteria


### PR DESCRIPTION
- FL2 now needs nucleation stress, therefore added.
- Energy_rate and magnitude output are now integrated into new energy output, so remove variables in parameters.par.
- Fix Northridge for attenuation adding missing parameters.
- Enable energy output.
- Change gmsh parameter in tpv5 (well I committed that by mistake, but does not hurt)