### PR TITLE
Make tpv16 input more clear

### DIFF
--- a/tpv16/README.md
+++ b/tpv16/README.md
@@ -1,3 +1,3 @@
-# Additional preparation #
-In order to run the TPV16/17 benchmakrs first download https://strike.scec.org/cvws/download/tpv16/tpv16_17_input_files.zip and extract files here.
+# Additional preparation
+In order to run the TPV16/17 benchmarks first `wget https://strike.scec.org/cvws/download/tpv16/tpv16_17_input_files.zip` and extract files here.
 Make sure `tpv16_input_file.txt` exists.

--- a/tpv16/README.md
+++ b/tpv16/README.md
@@ -1,0 +1,3 @@
+# Additional preparation #
+In order to run the TPV16/17 benchmakrs first download https://strike.scec.org/cvws/download/tpv16/tpv16_17_input_files.zip and extract files here.
+Make sure `tpv16_input_file.txt` exists.

--- a/tpv16/tpv16_input_file.txt
+++ b/tpv16/tpv16_input_file.txt
@@ -1,1 +1,0 @@
-download https://strike.scec.org/cvws/download/tpv16/tpv16_17_input_files.zip and extract files here


### PR DESCRIPTION
I added a README, which tells the user to download the input files. If one does not replace `tpv16_input_file.txt` with the downloaded version, no error is thrown, but the fault parameters are not correctly initialized.