### PR TITLE
add forced_rupture_time to LSW benchmarks

### DIFF
--- a/tpv12_13/tpv12_13_fault.yaml
+++ b/tpv12_13/tpv12_13_fault.yaml
@@ -21,8 +21,9 @@
         mu_d:        0.10
         d_c:         0.50
         cohesion: -200000
-[Tnuc_n, Tnuc_s, Tnuc_d]: !ConstantMap
+[Tnuc_n, Tnuc_s, Tnuc_d, forced_rupture_time]: !ConstantMap
     map:
         Tnuc_n: 0
         Tnuc_s: 0
         Tnuc_d: 0
+        forced_rupture_time: 1e10

--- a/tpv33/tpv33_fault.yaml
+++ b/tpv33/tpv33_fault.yaml
@@ -52,8 +52,9 @@
         return s_xy0 + s_xy1;
       s_yz:     return 0.0;
       s_xz:     return 0.0;
-[Tnuc_n, Tnuc_s, Tnuc_d]: !ConstantMap
+[Tnuc_n, Tnuc_s, Tnuc_d, forced_rupture_time]: !ConstantMap
     map:
         Tnuc_n: 0
         Tnuc_s: 0
         Tnuc_d: 0
+        forced_rupture_time: 1e10

--- a/tpv34/tpv34_fault.yaml
+++ b/tpv34/tpv34_fault.yaml
@@ -47,8 +47,9 @@
         return s_xy0 + s_xy1;
       s_yz:     return 0.0;
       s_xz:     return 0.0;
-[Tnuc_n, Tnuc_s, Tnuc_d]: !ConstantMap
+[Tnuc_n, Tnuc_s, Tnuc_d, forced_rupture_time]: !ConstantMap
     map:
         Tnuc_n: 0
         Tnuc_s: 0
         Tnuc_d: 0
+        forced_rupture_time: 1e10

--- a/tpv5/fault.yaml
+++ b/tpv5/fault.yaml
@@ -30,9 +30,10 @@
         return 62000000;
       }
       return 70000000;
-[mu_s, mu_d, d_c, cohesion]: !ConstantMap
+[mu_s, mu_d, d_c, cohesion, forced_rupture_time]: !ConstantMap
   map:
      mu_s:        0.677
      mu_d:        0.525
      d_c:         0.4
      cohesion:    0.0
+     forced_rupture_time: 1e10


### PR DESCRIPTION
now required since FL2 and 16 have been merged into 16