### PR TITLE
Move plasticity mask to its own field (elastic convergence)

### DIFF
--- a/convergence_elastic/static_files/parameters.par
+++ b/convergence_elastic/static_files/parameters.par
@@ -34,8 +34,13 @@ ClusteredLTS = 1                               ! 1 for Global time stepping, 2,3
 &Output
 OutputFile = 'output/conv'
 Format = 10                                    ! Format (10= no output, 6=hdf5 output)
-!             |stress     |vel  |plastic strain output (if any)
-iOutputMask = 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+
+!             |stress     |vel
+iOutputMask = 1 1 1 1 1 1 1 1 1
+
+!                 |strain     |eta
+iPlasticityMask = 1 1 1 1 1 1 1
+
 TimeInterval =  5.                           ! Index of printed info at time
 refinement = 1
 


### PR DESCRIPTION
As the title already says, this commit merely splits an old output mask in the elastic convergence test. This was (at least to my estimate) already defunct before that: the plasticity output parameters are by now controlled through a mask parameter on their own and not part of the output mask anymore (feel free to correct me here, if I'm still wrong). Thus, this commit/PR does exactly move the plasticity mask to the newer parameter.

Reason for this commit: the convergence test for https://github.com/SeisSol/SeisSol/pull/829 fails otherwise right now—unless we make https://github.com/SeisSol/SeisSol/pull/829 a bit more resilient against masks which are too long.