### PR TITLE
remove parameters tagged as outdated + FixTimeStep + fix tpv16

### DIFF
--- a/Northridge/parameters.par
+++ b/Northridge/parameters.par
@@ -9,16 +9,13 @@ FreqRatio=100
 /
 
 &Boundaries
-BC_fs = 1                                      ! enable free surface boundaries
 BC_dr = 0                                      ! enable fault boundaries
-BC_of = 1                                      ! enable absorbing boundaries
 /
 
 &SourceType
 Type = 42   ! 42: finite source in netcdf format
 FileName = './northridge.nrf' ! input file.
 /
-
 
 &SpongeLayer
 /
@@ -50,10 +47,7 @@ SurfaceOutput = 1
 SurfaceOutputRefinement = 1
 SurfaceOutputInterval = 0.5
 
-printIntervalCriterion = 2          ! Criterion for index of printed info: 1=timesteps,2=time,3=timesteps+time
-
 pickdt = 0.005                       ! Pickpoint Sampling
-pickDtType = 1                       ! Pickpoint Type
 RFileName = 'offreceivers.dat'       ! Record Points in extra file
 
 xdmfWriterBackend = 'posix' ! (optional) The backend used in fault, wavefield,

--- a/Northridge_FL33/parameters.par
+++ b/Northridge_FL33/parameters.par
@@ -7,9 +7,7 @@ MaterialFileName = 'northridge_material.yaml'
 /
 
 &Boundaries
-BC_fs = 1                                      ! enable free surface boundaries
 BC_dr = 1                                      ! enable fault boundaries
-BC_of = 1                                      ! enable absorbing boundaries
 /
 
 &DynamicRupture
@@ -33,7 +31,6 @@ SlipRateOutputType=0        ! 0: (smoother) slip rate output evaluated from the 
 !see: https://seissol.readthedocs.io/en/latest/fault-output.html
 ! parameterize paraview file output
 &Elementwise
-printIntervalCriterion = 2                     ! 1=iteration, 2=time
 printtimeinterval_sec = 1.00                   ! Time interval at which output will be written
 OutputMask = 1 1 0 0 1 1 1 1 1 1 0             ! turn on and off fault outputs
 refinement_strategy = 2
@@ -53,7 +50,6 @@ meshgenerator = 'PUML'                         ! Name of meshgenerator (Gambit3D
 
 &Discretization
 CFL = 0.5                                      ! CFL number (<=1.0)
-FixTimeStep = 5                                ! Manualy chosen minimum time
 ClusteredLTS = 2                               ! 1 for Global time stepping, 2,3,5,... Local time stepping (advised value 2)
 !ClusteredLTS defines the multi-rate for the time steps of the clusters 2 for Local time stepping
 /
@@ -74,10 +70,7 @@ SurfaceOutput = 1
 SurfaceOutputRefinement = 1
 SurfaceOutputInterval = 0.5
 
-printIntervalCriterion = 2          ! Criterion for index of printed info: 1=timesteps,2=time,3=timesteps+time
-
 pickdt = 0.005                       ! Pickpoint Sampling
-pickDtType = 1                       ! Pickpoint Type
 RFileName = 'offreceivers.dat'       ! Record Points in extra file
 
 xdmfWriterBackend = 'posix' ! (optional) The backend used in fault, wavefield,

--- a/WP2_LOH1/parameters.par
+++ b/WP2_LOH1/parameters.par
@@ -7,16 +7,13 @@ MaterialFileName = 'loh1.yaml'
 /
 
 &Boundaries
-BC_fs = 1                                      ! enable free surface boundaries
 BC_dr = 0                                      ! enable fault boundaries
-BC_of = 1                                      ! enable absorbing boundaries
 /
 
 &SourceType
 Type = 42   ! 42: finite source in netcdf format
 FileName = 'source.nrf'                        ! input file.
 /
-
 
 &SpongeLayer
 /
@@ -28,7 +25,6 @@ meshgenerator = 'PUML'                         ! Name of meshgenerator (Gambit3D
 
 &Discretization
 CFL = 0.5                                      ! CFL number (<=1.0)
-FixTimeStep = 5                                ! Manualy chosen minimum time
 ClusteredLTS = 2                               ! 1 for Global time stepping, 2,3,5,... Local time stepping (advised value 2)
 !ClusteredLTS defines the multi-rate for the time steps of the clusters 2 for Local time stepping
 /
@@ -49,10 +45,7 @@ SurfaceOutput = 1
 SurfaceOutputRefinement = 1
 SurfaceOutputInterval = 0.5
 
-printIntervalCriterion = 2          ! Criterion for index of printed info: 1=timesteps,2=time,3=timesteps+time
-
 pickdt = 0.0005                      ! Pickpoint Sampling
-pickDtType = 1                       ! Pickpoint Type
 RFileName = 'recordPoints.dat'       ! Record Points in extra file
 
 xdmfWriterBackend = 'posix' ! (optional) The backend used in fault, wavefield,

--- a/WP2_LOH1/parameters_source_type_50.par
+++ b/WP2_LOH1/parameters_source_type_50.par
@@ -7,9 +7,7 @@ MaterialFileName = 'loh1.yaml'
 /
 
 &Boundaries
-BC_fs = 1                                      ! enable free surface boundaries
 BC_dr = 0                                      ! enable fault boundaries
-BC_of = 1                                      ! enable absorbing boundaries
 /
 
 &SourceType
@@ -28,7 +26,6 @@ meshgenerator = 'PUML'                         ! Name of meshgenerator (Gambit3D
 
 &Discretization
 CFL = 0.5                                      ! CFL number (<=1.0)
-FixTimeStep = 5                                ! Manualy chosen minimum time
 ClusteredLTS = 2                               ! 1 for Global time stepping, 2,3,5,... Local time stepping (advised value 2)
 !ClusteredLTS defines the multi-rate for the time steps of the clusters 2 for Local time stepping
 /
@@ -49,10 +46,7 @@ SurfaceOutput = 1
 SurfaceOutputRefinement = 1
 SurfaceOutputInterval = 0.5
 
-printIntervalCriterion = 2          ! Criterion for index of printed info: 1=timesteps,2=time,3=timesteps+time
-
 pickdt = 0.0005                      ! Pickpoint Sampling
-pickDtType = 1                       ! Pickpoint Type
 RFileName = 'recordPoints.dat'       ! Record Points in extra file
 
 xdmfWriterBackend = 'posix' ! (optional) The backend used in fault, wavefield,

--- a/WP2_LOH3/parameters.par
+++ b/WP2_LOH3/parameters.par
@@ -10,16 +10,13 @@ FreqRatio=100
 /
 
 &Boundaries
-BC_fs = 1                                      ! enable free surface boundaries
 BC_dr = 0                                      ! enable fault boundaries
-BC_of = 1                                      ! enable absorbing boundaries
 /
 
 &SourceType
 Type = 42   ! 42: finite source in netcdf format
 FileName = 'source.nrf'                        ! input file.
 /
-
 
 &SpongeLayer
 /
@@ -31,7 +28,6 @@ meshgenerator = 'PUML'                         ! Name of meshgenerator (Gambit3D
 
 &Discretization
 CFL = 0.5                                      ! CFL number (<=1.0)
-FixTimeStep = 5                                ! Manualy chosen minimum time
 ClusteredLTS = 2                               ! 1 for Global time stepping, 2,3,5,... Local time stepping (advised value 2)
 !ClusteredLTS defines the multi-rate for the time steps of the clusters 2 for Local time stepping
 /
@@ -52,10 +48,7 @@ SurfaceOutput = 1
 SurfaceOutputRefinement = 1
 SurfaceOutputInterval = 0.5
 
-printIntervalCriterion = 2          ! Criterion for index of printed info: 1=timesteps,2=time,3=timesteps+time
-
 pickdt = 0.0005                      ! Pickpoint Sampling
-pickDtType = 1                       ! Pickpoint Type
 RFileName = 'recordPoints.dat'       ! Record Points in extra file
 
 xdmfWriterBackend = 'posix' ! (optional) The backend used in fault, wavefield,

--- a/convergence_acoustic_elastic/convergence_ocean/parameters.par
+++ b/convergence_acoustic_elastic/convergence_ocean/parameters.par
@@ -34,7 +34,6 @@ Format = 10                           ! Format (0=IDL, 1=TECPLOT, 2=IBM DX, 4=Gi
 refinement = 0 
 TimeInterval = 0.1                  ! Index of printed info at time
 pickdt = 0.002                        ! Pickpoint Sampling
-pickDtType = 1                       ! Pickpoint Type
 RFileName = 'recordPoints.dat'          ! Record Points in extra file
 SurfaceOutput = 1
 SurfaceOutputRefinement = 3

--- a/convergence_acoustic_elastic/convergence_scholte/parameters.par
+++ b/convergence_acoustic_elastic/convergence_scholte/parameters.par
@@ -33,7 +33,6 @@ Format = 10                           ! Format (0=IDL, 1=TECPLOT, 2=IBM DX, 4=Gi
 refinement = 1
 TimeInterval = 0.1                 ! Index of printed info at time
 pickdt = 0.05                        ! Pickpoint Sampling
-pickDtType = 1                       ! Pickpoint Type
 RFileName = 'recordPoints.dat'          ! Record Points in extra file
 SurfaceOutput = 1
 SurfaceOutputRefinement = 1

--- a/convergence_acoustic_elastic/convergence_snell/parameters.par
+++ b/convergence_acoustic_elastic/convergence_snell/parameters.par
@@ -36,7 +36,6 @@ Format = 10                           ! Format (0=IDL, 1=TECPLOT, 2=IBM DX, 4=Gi
 refinement = 1
 TimeInterval = 0.02                   ! Index of printed info at time
 pickdt = 0.05                        ! Pickpoint Sampling
-pickDtType = 1                       ! Pickpoint Type
 RFileName = 'recordPoints.dat'          ! Record Points in extra file
 /
 

--- a/convergence_elastic/elastic_convergence_runner/template/parameters.tmpl
+++ b/convergence_elastic/elastic_convergence_runner/template/parameters.tmpl
@@ -24,7 +24,6 @@ meshgenerator = 'Netcdf'
 
 &Discretization
 CFL = 0.5
-FixTimeStep = 5
 ClusteredLTS = 1
 /
 
@@ -36,10 +35,7 @@ iPlasticityMask = 1 1 1 1 1 1 1
 TimeInterval =  5.
 refinement = 1
 
-printIntervalCriterion = 2
-
 pickdt = 0.05
-pickDtType = 1
 nRecordPoints = 2
 RFileName = '{{ working_dir }}/recordPoints.dat'
 

--- a/convergence_elastic/static_files/parameters.par
+++ b/convergence_elastic/static_files/parameters.par
@@ -26,7 +26,6 @@ meshgenerator = 'Netcdf'                       ! Name of meshgenerator (Gambit3D
 
 &Discretization
 CFL = 0.5                                      ! CFL number (<=1.0)
-FixTimeStep = 5                                ! Manualy chosen minimum time
 ClusteredLTS = 1                               ! 1 for Global time stepping, 2,3,5,... Local time stepping (advised value 2)
 !ClusteredLTS defines the multi-rate for the time steps of the clusters 2 for Local time stepping
 /
@@ -44,10 +43,7 @@ iPlasticityMask = 1 1 1 1 1 1 1
 TimeInterval =  5.                           ! Index of printed info at time
 refinement = 1
 
-printIntervalCriterion = 2          ! Criterion for index of printed info: 1=timesteps,2=time,3=timesteps+time
-
 pickdt = 0.05                        ! Pickpoint Sampling
-pickDtType = 1                       ! Pickpoint Type
 RFileName = 'recordPoints.dat'       ! Record Points in extra file
 
 xdmfWriterBackend = 'posix' ! (optional) The backend used in fault, wavefield,

--- a/tpv101/parameters101.par
+++ b/tpv101/parameters101.par
@@ -7,13 +7,8 @@ MaterialFileName = 'tpv101_material.yaml'
 /
 
 &Boundaries
-BC_fs = 1                                      ! enable free surface boundaries
 BC_dr = 1                                      ! enable fault boundaries
-BC_of = 1                                      ! enable absorbing boundaries
 /
-
-
-
 
 &DynamicRupture
 FL = 3                                       ! Friction law
@@ -47,7 +42,6 @@ SlipRateOutputType=0        ! 0: (smoother) slip rate output evaluated from the 
 !see: https://seissol.readthedocs.io/en/latest/fault-output.html
 ! parameterize paraview file output
 &Elementwise
-printIntervalCriterion = 2                     ! 1=iteration, 2=time
 printtimeinterval_sec = 0.5                    ! Time interval at which output will be written
 OutputMask = 1 1 1 1 1 1 1 1 1 1 1 1 !           ! turn on and off fault outputs
 refinement_strategy = 2
@@ -75,7 +69,6 @@ meshgenerator = 'PUML'                         ! Name of meshgenerator (Gambit3D
 
 &Discretization
 CFL = 0.5                                      ! CFL number (<=1.0)
-FixTimeStep = 5                                ! Manualy chosen minimum time
 ClusteredLTS = 2                               ! 1 for Global time stepping, 2,3,5,... Local time stepping (advised value 2)
 !ClusteredLTS defines the multi-rate for the time steps of the clusters 2 for Local time stepping
 /
@@ -94,7 +87,6 @@ refinement = 1
 ! off-fault ascii receivers
 RFileName = 'tpv101_receivers.dat'          ! Record Points in extra file
 pickdt = 0.005                                 ! Pickpoint Sampling
-pickDtType = 1                                 ! Pickpoint Type
 ! (Optional) Synchronization point for receivers.
 !            If omitted, receivers are written at the end of the simulation.
 ReceiverOutputInterval = 0.5
@@ -103,8 +95,6 @@ ReceiverOutputInterval = 0.5
 SurfaceOutput = 0
 SurfaceOutputRefinement = 2
 SurfaceOutputInterval = 5.0
-
-printIntervalCriterion = 2          ! Criterion for index of printed info: 1=timesteps,2=time,3=timesteps+time
 
 !xdmfWriterBackend = 'posix' ! (optional) The backend used in fault, wavefield,
 ! and free-surface output. The HDF5 backend is only supported when SeisSol is compiled with

--- a/tpv104/parameters.par
+++ b/tpv104/parameters.par
@@ -6,9 +6,7 @@ MaterialFileName = 'material.yaml'
 /
 
 &Boundaries
-BC_fs = 1
 BC_dr = 1                               ! Fault boundaries
-BC_of = 1                               ! Absorbing boundaries
 /
 
 &DynamicRupture
@@ -33,7 +31,6 @@ OutputPointType = 5         ! Type (0: no output, 1: take GP's 2: 4 points per s
 /
 
 &Elementwise
-printIntervalCriterion = 2      ! 1=iteration, 2=time
 printtimeinterval_sec = 1.      ! Time interval at which output will be written
 !printtimeinterval = 1568       ! Index of printed info at timesteps
 OutputMask = 1 1 1 1 1 1 1 1 1  1 ! output 1/ yes, 0/ no - position: 1/ slip rate 2/ stress 3/ normal velocity 4/ in case of rate and state output friction and state variable
@@ -65,26 +62,16 @@ MeshFile = 'mesh/tpv103-nsym-250'             ! Name of mesh file
 /
 
 &Discretization
-Order = 4                       ! Order of accuracy in space and time
-Material = 1                         ! Material order
 CFL = 0.5                            ! CFL number (<=1.0)
-FixTimeStep = 5                      ! Manualy chosen minimum time
-
-DGMethod = 1                         ! Local time stepping
-!IterationCriterion = 1               ! Local time stepping synchronisation criterion
 ClusteredLTS =2
 /
 
 &Output
 OutputFile = 'output-rsl/tpv104'
 iOutputMask = 1 1 1 1 1 1 1 1 1      ! Variables ouptut
-iOutputMaskMaterial = 1 1 1          ! Material output
 Format = 10                           ! Format (0=IDL, 1=TECPLOT, 2=IBM DX, 4=GiD))
-!Interval = 100000                    ! Index of printed info at timesteps
 TimeInterval = 0.25                   ! Index of printed info at time
-printIntervalCriterion = 2           ! Criterion for index of printed info: 1=timesteps,2=time,3=timesteps+time
 pickdt = 0.005                       ! Pickpoint Sampling
-pickDtType = 1                       ! Pickpoint Type
 FaultOutputFlag = 1                  ! DR output (add this line only if DR is active)
 RFileName = 'tpv104_receivers.dat'      ! Record Points in extra file
 !checkPointInterval = 1.5 ! Set to 0 to disable checkpointing

--- a/tpv105/parameters.par
+++ b/tpv105/parameters.par
@@ -7,13 +7,8 @@ MaterialFileName = 'tpv105_material.yaml'
 /
 
 &Boundaries
-BC_fs = 1                                      ! enable free surface boundaries
 BC_dr = 1                                      ! enable fault boundaries
-BC_of = 1                                      ! enable absorbing boundaries
 /
-
-
-
 
 &DynamicRupture
 FL = 103                                       ! Friction law  
@@ -54,7 +49,6 @@ SlipRateOutputType=1        ! 0: (smoother) slip rate output evaluated from the 
 !see: https://seissol.readthedocs.io/en/latest/fault-output.html
 ! parameterize paraview file output
 &Elementwise
-printIntervalCriterion = 2                     ! 1=iteration, 2=time
 printtimeinterval_sec = 0.5                    ! Time interval at which output will be written
 OutputMask = 1 1 1 1 1 1 1 1 1 1 1 1           ! turn on and off fault outputs
 refinement_strategy = 2
@@ -82,7 +76,6 @@ meshgenerator = 'PUML'                         ! Name of meshgenerator (Gambit3D
 
 &Discretization
 CFL = 0.5                                      ! CFL number (<=1.0)
-FixTimeStep = 5                                ! Manualy chosen minimum time
 ClusteredLTS = 2                               ! 1 for Global time stepping, 2,3,5,... Local time stepping (advised value 2)
 !ClusteredLTS defines the multi-rate for the time steps of the clusters 2 for Local time stepping
 /
@@ -101,7 +94,6 @@ refinement = 1
 ! off-fault ascii receivers
 RFileName = 'tpv105_receivers.dat'          ! Record Points in extra file
 pickdt = 0.005                                 ! Pickpoint Sampling
-pickDtType = 1                                 ! Pickpoint Type
 ! (Optional) Synchronization point for receivers.
 !            If omitted, receivers are written at the end of the simulation.
 ReceiverOutputInterval = 0.5
@@ -110,8 +102,6 @@ ReceiverOutputInterval = 0.5
 SurfaceOutput = 1
 SurfaceOutputRefinement = 2
 SurfaceOutputInterval = 5.0
-
-printIntervalCriterion = 2          ! Criterion for index of printed info: 1=timesteps,2=time,3=timesteps+time
 
 xdmfWriterBackend = 'posix' ! (optional) The backend used in fault, wavefield,
 ! and free-surface output. The HDF5 backend is only supported when SeisSol is compiled with

--- a/tpv12_13/parameters.par
+++ b/tpv12_13/parameters.par
@@ -10,9 +10,7 @@ Tv = 0.03
 /
 
 &Boundaries
-BC_fs = 1                                      ! enable free surface boundaries
 BC_dr = 1                                      ! enable fault boundaries
-BC_of = 1                                      ! enable absorbing boundaries
 /
 
 &DynamicRupture
@@ -39,7 +37,6 @@ SlipRateOutputType=1        ! 0: (smoother) slip rate output evaluated from the 
 !see: https://seissol.readthedocs.io/en/latest/fault-output.html
 ! parameterize paraview file output
 &Elementwise
-printIntervalCriterion = 2                     ! 1=iteration, 2=time
 printtimeinterval_sec = 1.0                    ! Time interval at which output will be written
 OutputMask = 1 1 1 0 1 1 1 1 1 1 1             ! turn on and off fault outputs
 refinement_strategy = 2
@@ -67,7 +64,6 @@ meshgenerator = 'PUML'                         ! Name of meshgenerator (Gambit3D
 
 &Discretization
 CFL = 0.5                                      ! CFL number (<=1.0)
-FixTimeStep = 5                                ! Manualy chosen minimum time
 ClusteredLTS = 2                               ! 1 for Global time stepping, 2,3,5,... Local time stepping (advised value 2)
 !ClusteredLTS defines the multi-rate for the time steps of the clusters 2 for Local time stepping
 /
@@ -88,10 +84,7 @@ SurfaceOutput = 1
 SurfaceOutputRefinement = 1
 SurfaceOutputInterval = 5.0
 
-printIntervalCriterion = 2          ! Criterion for index of printed info: 1=timesteps,2=time,3=timesteps+time
-
 pickdt = 0.005                       ! Pickpoint Sampling
-pickDtType = 1                       ! Pickpoint Type
 RFileName = 'tpv12_13_receivers.dat'      ! Record Points in extra file
 
 xdmfWriterBackend = 'posix' ! (optional) The backend used in fault, wavefield,

--- a/tpv16/parameters.par
+++ b/tpv16/parameters.par
@@ -7,9 +7,7 @@ MaterialFileName = 'tpv16_material.yaml'
 /
 
 &Boundaries
-BC_fs = 1                                      ! enable free surface boundaries
 BC_dr = 1                                      ! enable fault boundaries
-BC_of = 1                                      ! enable absorbing boundaries
 /
 
 &DynamicRupture
@@ -36,7 +34,6 @@ SlipRateOutputType=1        ! 0: (smoother) slip rate output evaluated from the 
 !see: https://seissol.readthedocs.io/en/latest/fault-output.html
 ! parameterize paraview file output
 &Elementwise
-printIntervalCriterion = 2                     ! 1=iteration, 2=time
 printtimeinterval_sec = 1.0                    ! Time interval at which output will be written
 OutputMask = 1 1 1 0 1 1 1 1 1 1 1             ! turn on and off fault outputs
 refinement_strategy = 2
@@ -64,7 +61,6 @@ meshgenerator = 'PUML'                         ! Name of meshgenerator (Gambit3D
 
 &Discretization
 CFL = 0.5                                      ! CFL number (<=1.0)
-FixTimeStep = 5                                ! Manualy chosen minimum time
 ClusteredLTS = 2                               ! 1 for Global time stepping, 2,3,5,... Local time stepping (advised value 2)
 !ClusteredLTS defines the multi-rate for the time steps of the clusters 2 for Local time stepping
 /
@@ -85,10 +81,7 @@ SurfaceOutput = 1
 SurfaceOutputRefinement = 2
 SurfaceOutputInterval = 5.0
 
-printIntervalCriterion = 2          ! Criterion for index of printed info: 1=timesteps,2=time,3=timesteps+time
-
 pickdt = 0.005                       ! Pickpoint Sampling
-pickDtType = 1                       ! Pickpoint Type
 RFileName = 'tpv16_receivers.dat'      ! Record Points in extra file
 
 xdmfWriterBackend = 'posix' ! (optional) The backend used in fault, wavefield,

--- a/tpv16/tpv16_fault.yaml
+++ b/tpv16/tpv16_fault.yaml
@@ -26,4 +26,3 @@
         Tnuc_n: 0
         Tnuc_s: 0
         Tnuc_d: 0
-        forced_rupture_time: 1e10

--- a/tpv24/parameters.par
+++ b/tpv24/parameters.par
@@ -7,9 +7,7 @@ MaterialFileName = 'tpv24_material.yaml'
 /
 
 &Boundaries
-BC_fs = 1                                      ! enable free surface boundaries
 BC_dr = 1                                      ! enable fault boundaries
-BC_of = 1                                      ! enable absorbing boundaries
 /
 
 &DynamicRupture
@@ -36,7 +34,6 @@ SlipRateOutputType=1        ! 0: (smoother) slip rate output evaluated from the 
 !see: https://seissol.readthedocs.io/en/latest/fault-output.html
 ! parameterize paraview file output
 &Elementwise
-printIntervalCriterion = 2                     ! 1=iteration, 2=time
 printtimeinterval_sec = 1.0                    ! Time interval at which output will be written
 OutputMask = 1 1 1 0 1 1 1 1 1 1 1             ! turn on and off fault outputs
 refinement_strategy = 2
@@ -64,7 +61,6 @@ meshgenerator = 'PUML'                         ! Name of meshgenerator (Gambit3D
 
 &Discretization
 CFL = 0.5                                      ! CFL number (<=1.0)
-FixTimeStep = 5                                ! Manualy chosen minimum time
 ClusteredLTS = 2                               ! 1 for Global time stepping, 2,3,5,... Local time stepping (advised value 2)
 !ClusteredLTS defines the multi-rate for the time steps of the clusters 2 for Local time stepping
 /
@@ -85,10 +81,7 @@ SurfaceOutput = 1
 SurfaceOutputRefinement = 2
 SurfaceOutputInterval = 5.0
 
-printIntervalCriterion = 2          ! Criterion for index of printed info: 1=timesteps,2=time,3=timesteps+time
-
 pickdt = 0.005                       ! Pickpoint Sampling
-pickDtType = 1                       ! Pickpoint Type
 RFileName = 'tpv24_receivers.dat'      ! Record Points in extra file
 
 xdmfWriterBackend = 'posix' ! (optional) The backend used in fault, wavefield,

--- a/tpv29/parameters.par
+++ b/tpv29/parameters.par
@@ -7,9 +7,7 @@ MaterialFileName = 'tpv29_material.yaml'
 /
 
 &Boundaries
-BC_fs = 1                                      ! enable free surface boundaries
 BC_dr = 1                                      ! enable fault boundaries
-BC_of = 1                                      ! enable absorbing boundaries
 /
 
 &DynamicRupture
@@ -36,7 +34,6 @@ SlipRateOutputType=1        ! 0: (smoother) slip rate output evaluated from the 
 !see: https://seissol.readthedocs.io/en/latest/fault-output.html
 ! parameterize paraview file output
 &Elementwise
-printIntervalCriterion = 2                     ! 1=iteration, 2=time
 printtimeinterval_sec = 1.0                    ! Time interval at which output will be written
 OutputMask = 1 1 1 0 1 1 1 1 1 1 1             ! turn on and off fault outputs
 refinement_strategy = 2
@@ -64,7 +61,6 @@ meshgenerator = 'PUML'                         ! Name of meshgenerator (Gambit3D
 
 &Discretization
 CFL = 0.5                                      ! CFL number (<=1.0)
-FixTimeStep = 5                                ! Manualy chosen minimum time
 ClusteredLTS = 2                               ! 1 for Global time stepping, 2,3,5,... Local time stepping (advised value 2)
 !ClusteredLTS defines the multi-rate for the time steps of the clusters 2 for Local time stepping
 /
@@ -85,10 +81,7 @@ SurfaceOutput = 1
 SurfaceOutputRefinement = 2
 SurfaceOutputInterval = 5.0
 
-printIntervalCriterion = 2          ! Criterion for index of printed info: 1=timesteps,2=time,3=timesteps+time
-
 pickdt = 0.005                       ! Pickpoint Sampling
-pickDtType = 1                       ! Pickpoint Type
 RFileName = 'tpv29_receivers.dat'      ! Record Points in extra file
 
 xdmfWriterBackend = 'posix' ! (optional) The backend used in fault, wavefield,

--- a/tpv33/parameters.par
+++ b/tpv33/parameters.par
@@ -7,9 +7,7 @@ MaterialFileName = 'tpv33_material.yaml'
 /
 
 &Boundaries
-BC_fs = 1                                      ! enable free surface boundaries
 BC_dr = 1                                      ! enable fault boundaries
-BC_of = 1                                      ! enable absorbing boundaries
 /
 
 &DynamicRupture
@@ -34,7 +32,6 @@ SlipRateOutputType=1        ! 0: (smoother) slip rate output evaluated from the 
 !see: https://seissol.readthedocs.io/en/latest/fault-output.html
 ! parameterize paraview file output
 &Elementwise
-printIntervalCriterion = 2                     ! 1=iteration, 2=time
 printtimeinterval_sec = 1.0                    ! Time interval at which output will be written
 OutputMask = 1 1 1 0 1 1 1 1 1 1 1             ! turn on and off fault outputs
 refinement_strategy = 2
@@ -62,7 +59,6 @@ meshgenerator = 'PUML'                         ! Name of meshgenerator (Gambit3D
 
 &Discretization
 CFL = 0.5                                      ! CFL number (<=1.0)
-FixTimeStep = 5                                ! Manualy chosen minimum time
 ClusteredLTS = 2                               ! 1 for Global time stepping, 2,3,5,... Local time stepping (advised value 2)
 !ClusteredLTS defines the multi-rate for the time steps of the clusters 2 for Local time stepping
 /
@@ -83,10 +79,7 @@ SurfaceOutput = 1
 SurfaceOutputRefinement = 2
 SurfaceOutputInterval = 5.0
 
-printIntervalCriterion = 2          ! Criterion for index of printed info: 1=timesteps,2=time,3=timesteps+time
-
 pickdt = 0.005                       ! Pickpoint Sampling
-pickDtType = 1                       ! Pickpoint Type
 RFileName = 'tpv33_receivers.dat'    ! Record Points in extra file
 
 xdmfWriterBackend = 'posix' ! (optional) The backend used in fault, wavefield,

--- a/tpv34/parameters.par
+++ b/tpv34/parameters.par
@@ -7,9 +7,7 @@ MaterialFileName = 'tpv34_material.yaml'
 /
 
 &Boundaries
-BC_fs = 1                                      ! enable free surface boundaries
 BC_dr = 1                                      ! enable fault boundaries
-BC_of = 1                                      ! enable absorbing boundaries
 /
 
 &DynamicRupture
@@ -34,7 +32,6 @@ SlipRateOutputType = 1      ! 0: (smoother) slip rate output evaluated from the 
 !see: https://seissol.readthedocs.io/en/latest/fault-output.html
 ! parameterize paraview file output
 &Elementwise
-printIntervalCriterion = 2                     ! 1=iteration, 2=time
 printtimeinterval_sec = 1.0                    ! Time interval at which output will be written
 OutputMask = 1 1 1 1 1 1 1 1 1 1 1             ! turn on and off fault outputs
 refinement_strategy = 2
@@ -62,7 +59,6 @@ meshgenerator = 'PUML'                         ! Name of meshgenerator (Gambit3D
 
 &Discretization
 CFL = 0.5                                      ! CFL number (<=1.0)
-FixTimeStep = 5                                ! Manualy chosen minimum time
 ClusteredLTS = 2                               ! 1 for Global time stepping, 2,3,5,... Local time stepping (advised value 2)
 !ClusteredLTS defines the multi-rate for the time steps of the clusters 2 for Local time stepping
 /
@@ -83,10 +79,7 @@ SurfaceOutput = 1
 SurfaceOutputRefinement = 2
 SurfaceOutputInterval = 5.0
 
-printIntervalCriterion = 2                     ! Criterion for index of printed info: 1=timesteps,2=time,3=timesteps+time
-
 pickdt = 0.005                                 ! Pickpoint Sampling
-pickDtType = 1                                 ! Pickpoint Type
 RFileName = 'tpv34_receivers.dat'              ! Record Points in extra file
 
 EnergyOutput = 1 ! Computation of energy, written in csv file

--- a/tpv5/parameters.par
+++ b/tpv5/parameters.par
@@ -7,9 +7,7 @@ MaterialFileName = 'tpv5_material.yaml'
 /
 
 &Boundaries
-BC_fs = 1                                      ! enable free surface boundaries
 BC_dr = 1                                      ! enable fault boundaries
-BC_of = 1                                      ! enable absorbing boundaries
 /
 
 &DynamicRupture
@@ -34,7 +32,6 @@ SlipRateOutputType=1        ! 0: (smoother) slip rate output evaluated from the 
 !see: https://seissol.readthedocs.io/en/latest/fault-output.html
 ! parameterize paraview file output
 &Elementwise
-printIntervalCriterion = 2                     ! 1=iteration, 2=time
 printtimeinterval_sec = 1.0                    ! Time interval at which output will be written
 OutputMask = 1 1 1 0 1 1 1 1 1 1 1             ! turn on and off fault outputs
 refinement_strategy = 2
@@ -62,7 +59,6 @@ meshgenerator = 'PUML'                         ! Name of meshgenerator (Gambit3D
 
 &Discretization
 CFL = 0.5                                      ! CFL number (<=1.0)
-FixTimeStep = 5                                ! Manualy chosen minimum time
 ClusteredLTS = 2                               ! 1 for Global time stepping, 2,3,5,... Local time stepping (advised value 2)
 !ClusteredLTS defines the multi-rate for the time steps of the clusters 2 for Local time stepping
 /
@@ -83,10 +79,7 @@ SurfaceOutput = 1
 SurfaceOutputRefinement = 2
 SurfaceOutputInterval = 5.0
 
-printIntervalCriterion = 2          ! Criterion for index of printed info: 1=timesteps,2=time,3=timesteps+time
-
 pickdt = 0.005                       ! Pickpoint Sampling
-pickDtType = 1                       ! Pickpoint Type
 RFileName = 'tpv5_receivers.dat'      ! Record Points in extra file
 
 xdmfWriterBackend = 'posix' ! (optional) The backend used in fault, wavefield,

--- a/tpv6_7/parameters.par
+++ b/tpv6_7/parameters.par
@@ -7,9 +7,7 @@ MaterialFileName = 'tpv6_material.yaml'
 /
 
 &Boundaries
-BC_fs = 1                                      ! enable free surface boundaries
 BC_dr = 1                                      ! enable fault boundaries
-BC_of = 1                                      ! enable absorbing boundaries
 /
 
 &DynamicRupture
@@ -36,7 +34,6 @@ SlipRateOutputType=1        ! 0: (smoother) slip rate output evaluated from the 
 !see: https://seissol.readthedocs.io/en/latest/fault-output.html
 ! parameterize paraview file output
 &Elementwise
-printIntervalCriterion = 2                     ! 1=iteration, 2=time
 printtimeinterval_sec = 1.0                    ! Time interval at which output will be written
 OutputMask = 1 1 1 0 1 1 1 1 1 1 1             ! turn on and off fault outputs
 refinement_strategy = 2
@@ -64,7 +61,6 @@ meshgenerator = 'PUML'                         ! Name of meshgenerator (Gambit3D
 
 &Discretization
 CFL = 0.5                                      ! CFL number (<=1.0)
-FixTimeStep = 5                                ! Manualy chosen minimum time
 ClusteredLTS = 2                               ! 1 for Global time stepping, 2,3,5,... Local time stepping (advised value 2)
 !ClusteredLTS defines the multi-rate for the time steps of the clusters 2 for Local time stepping
 /
@@ -85,10 +81,7 @@ SurfaceOutput = 1
 SurfaceOutputRefinement = 2
 SurfaceOutputInterval = 5.0
 
-printIntervalCriterion = 2          ! Criterion for index of printed info: 1=timesteps,2=time,3=timesteps+time
-
 pickdt = 0.005                       ! Pickpoint Sampling
-pickDtType = 1                       ! Pickpoint Type
 RFileName = 'tpv6_receivers.dat'      ! Record Points in extra file
 
 xdmfWriterBackend = 'posix' ! (optional) The backend used in fault, wavefield,


### PR DESCRIPTION
- Remove FixTimeStep:  It is better not to fix FixTimeStep (in general). Then if you turn on viscoelasticity it gets automatically calculated.
- David has identified a few outdated parameters and I therefore remove them.
- Small fix on tpv16 (as force_rupture_time is already defined in the yaml file).