### PR TITLE
Fix TPV24 pre stress

### DIFF
--- a/tpv24/generating_the_mesh.sh
+++ b/tpv24/generating_the_mesh.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-prefix=tpv24_100m
+prefix=tpv24_400m
 # Generate the mesh using gmsh
 #for gmsh, see http://gmsh.info/#Download
 gmsh -3 $prefix.geo

--- a/tpv24/parameters.par
+++ b/tpv24/parameters.par
@@ -35,7 +35,7 @@ SlipRateOutputType=1        ! 0: (smoother) slip rate output evaluated from the 
 ! parameterize paraview file output
 &Elementwise
 printtimeinterval_sec = 1.0                    ! Time interval at which output will be written
-OutputMask = 1 1 1 0 1 1 1 1 1 1 1             ! turn on and off fault outputs
+OutputMask = 1 1 1 1 1 1 1 1 1 1 1             ! turn on and off fault outputs
 refinement_strategy = 2
 refinement = 1
 /

--- a/tpv24/tpv24_fault.yaml
+++ b/tpv24/tpv24_fault.yaml
@@ -8,15 +8,15 @@
   function: |
       function f (x)
         b22 = 0.926793
-        b23 = -0.169029
         b33 = 1.073206
+        b23 = -0.169029
         z = x["z"]
-        s_zz = 2670*9.8*z
-        Pf = -1000*9.8*z
+        s_zz = 2670.0 * 9.8 * z
+        p_f = -1000.0 * 9.8 * z
         if (z >= -15600.0) then
-          s_xx = b22 * (s_zz + Pf) - Pf
-          s_xy = b23 * (s_zz + Pf) - Pf
-          s_yy = b33 * (s_zz + Pf) - Pf
+          s_xx = b22 * (s_zz + p_f)
+          s_xy = b23 * (s_zz + p_f)
+          s_yy = b33 * (s_zz + p_f)
         else
           s_xx = s_zz
           s_xy = 0.0
@@ -51,7 +51,7 @@
         r_crit = 4000.0
         Vs = 3464.0
         if (r <= r_crit) then
-          forced_rupture_time =  r/(0.7*Vs)+(0.081*r_crit/(0.7*Vs))*(1.0/(1.0-(r/r_crit)^2)-1.0)
+          forced_rupture_time = r/(0.7*Vs)+(0.081*r_crit/(0.7*Vs))*(1.0/(1.0-(r/r_crit)^2)-1.0)
         else
           forced_rupture_time = 1000000000.0
         end


### PR DESCRIPTION
When we subtract the fluid pressure, as it was initially done, the fault breaks everywhere at once. Compare for example TVP12/13, where we have a similar stress tensor. With the new stress, I get the expected behaviour.