### PR TITLE
Fix TPV104 fault

### DIFF
--- a/tpv104/fault.yaml
+++ b/tpv104/fault.yaml
@@ -17,9 +17,11 @@
   function: |
       function f (x)
         x1 = math.min(18000.0, math.max(15000., math.abs(x["x"])))
-        z1 = math.min(18000.0, math.max(15000., math.abs(x["z"])))
+        z1 = math.min(10500.0, math.max(7500., math.abs(x["z"] + 7500)))
+
         box_x = 0.5*(1.0+math.tanh(3000.0/(x1-15000.0-3000.0) + 3000.0 / (x1-15000.0)))
-        box_z = 0.5*(1.0+math.tanh(3000.0/(z1-15000.0-3000.0) + 3000.0 / (z1-15000.0)))
+        box_z = 0.5*(1.0+math.tanh(3000.0/(z1-7500.0-3000.0) + 3000.0 / (z1-7500.0)))
+
         r = math.sqrt(x["x"]^2 + x["y"]^2 + (x["z"]+7500)^2)
 
         if (r <= 3000.0) then

--- a/tpv104/generating_the_mesh.sh
+++ b/tpv104/generating_the_mesh.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -euo pipefail
+
+prefix=tpv104_f200m
+# Generate the mesh using gmsh
+#for gmsh, see http://gmsh.info/#Download
+gmsh -3 -algo hxt $prefix.geo
+
+# Convert the mesh from neu to hdf5 using pumgen
+# for pumgen, see https://github.com/SeisSol/PUMGen/wiki/How-to-compile-PUMGen
+pumgen $prefix.msh -s msh2

--- a/tpv104/mesh_file
+++ b/tpv104/mesh_file
@@ -1,1 +1,0 @@
-same as for tpv5 (see ../tpv5)

--- a/tpv104/parameters.par
+++ b/tpv104/parameters.par
@@ -58,7 +58,7 @@ PPFileName = 'tpv104_faultreceivers.dat'
             
 &MeshNml
 meshgenerator = 'PUML'       ! Name of meshgenerator (format)
-MeshFile = 'mesh/tpv103-nsym-250'             ! Name of mesh file
+MeshFile = 'tpv104_f200m.puml.h5'             ! Name of mesh file
 /
 
 &Discretization
@@ -67,7 +67,7 @@ ClusteredLTS =2
 /
 
 &Output
-OutputFile = 'output-rsl/tpv104'
+OutputFile = 'output/tpv104'
 iOutputMask = 1 1 1 1 1 1 1 1 1      ! Variables ouptut
 Format = 10                           ! Format (0=IDL, 1=TECPLOT, 2=IBM DX, 4=GiD))
 TimeInterval = 0.25                   ! Index of printed info at time

--- a/tpv104/tpv104_f200m.geo
+++ b/tpv104/tpv104_f200m.geo
@@ -1,0 +1,165 @@
+/**
+ * @file
+ * This file is part of SeisSol.
+ *
+ * @author Thomas Ulrich 
+ *
+ * @section LICENSE
+ * Copyright (c) 2014-2022, SeisSol Group
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+*/
+
+
+lc = 5e3;
+lc_fault = 200;
+
+Fault_length = 36e3;
+Fault_width = 18e3;
+Fault_dip = 90*Pi/180.;
+
+// Nucleation in X,Z local coordinates
+X_nucl = 0e3;
+Width_nucl = 0.5*Fault_width;
+R_nucl = 1.5e3;
+lc_nucl = 200;
+
+Xmax = 60e3;
+Xmin = -Xmax;
+Ymin = -Xmax +  0.5 * Fault_width  *Cos(Fault_dip);
+Ymax =  Xmax + 0.5 * Fault_width  *Cos(Fault_dip);
+Zmin = -Xmax;
+
+// Create the Volume
+Point(1) = {Xmin, Ymin, 0, lc};
+Point(2) = {Xmin, Ymax, 0, lc};
+Point(3) = {Xmax, Ymax, 0, lc};
+Point(4) = {Xmax, Ymin, 0, lc};
+Line(1) = {1, 2};
+Line(2) = {2, 3};
+Line(3) = {3, 4};
+Line(4) = {4, 1};
+Curve Loop(5) = {1,2,3,4};
+Plane Surface(1) = {5};
+Extrude {0,0, Zmin} { Surface{1}; }
+
+// Create the fault
+Point(100) = {-0.5*Fault_length, Fault_width  *Cos(Fault_dip), -Fault_width  *Sin(Fault_dip), lc};
+Point(101) = {-0.5*Fault_length, 0, 0e3, lc};
+Point(102) = {0.5*Fault_length, 0,  0e3, lc};
+Point(103) = {0.5*Fault_length, Fault_width  *Cos(Fault_dip), -Fault_width  *Sin(Fault_dip), lc};
+Line(100) = {100, 101};
+Line(101) = {101, 102};
+Line{101} In Surface{1};
+Line(102) = {102, 103};
+Line(103) = {103, 100};
+
+// Create nucleation patch
+/*
+Point(200) = {X_nucl, Width_nucl*Cos(Fault_dip), -Width_nucl  *Sin(Fault_dip), lc_nucl};
+Point(201) = {X_nucl, (Width_nucl + R_nucl) * Cos(Fault_dip), -(Width_nucl+R_nucl)  *Sin(Fault_dip), lc_nucl};
+Point(202) = {X_nucl + R_nucl, Width_nucl*Cos(Fault_dip), -Width_nucl  *Sin(Fault_dip), lc_nucl};
+Point(203) = {X_nucl, (Width_nucl - R_nucl) * Cos(Fault_dip), -(Width_nucl-R_nucl)  *Sin(Fault_dip), lc_nucl};
+Point(204) = {X_nucl - R_nucl, Width_nucl*Cos(Fault_dip), -Width_nucl  *Sin(Fault_dip), lc_nucl};
+Circle(200) = {201,200,202};
+Circle(201) = {202,200,203};
+Circle(202) = {203,200,204};
+Circle(203) = {204,200,201};
+Curve Loop(204) = {200,201,202,203};
+Plane Surface(200) = {204};
+*/
+
+Point(201) = {X_nucl + R_nucl , (Width_nucl + R_nucl) * Cos(Fault_dip), -(Width_nucl+R_nucl)  *Sin(Fault_dip), lc_nucl};
+Point(202) = {X_nucl + R_nucl , (Width_nucl - R_nucl) * Cos(Fault_dip), -(Width_nucl-R_nucl)  *Sin(Fault_dip), lc_nucl};
+Point(203) = {X_nucl - R_nucl , (Width_nucl - R_nucl) * Cos(Fault_dip), -(Width_nucl-R_nucl)  *Sin(Fault_dip), lc_nucl};
+Point(204) = {X_nucl - R_nucl , (Width_nucl + R_nucl) * Cos(Fault_dip), -(Width_nucl+R_nucl)  *Sin(Fault_dip), lc_nucl};
+Line(200) = {201, 202};
+Line(201) = {202, 203};
+Line(202) = {203, 204};
+Line(203) = {204, 201};
+Curve Loop(204) = {200,201,202,203};
+Plane Surface(200) = {204};
+
+Curve Loop(105) = {100,101,102,103};
+Plane Surface(100) = {105, 204};
+
+// There is a bug in "Attractor", we need to define a Ruled surface in FaceList
+Line Loop(106) = {100,101,102,103};
+Ruled Surface(101) = {106};
+Ruled Surface(201) = {204};
+
+Surface{100,200} In Volume{1};
+
+// Managing coarsening away from the fault
+// Attractor field returns the distance to the curve (actually, the
+// distance to 100 equidistant points on the curve)
+Field[1] = Distance;
+Field[1].FacesList = {101};
+
+// Matheval field returns "distance squared + lc/20"
+Field[2] = MathEval;
+//Field[2].F = Sprintf("0.02*F1 + 0.00001*F1^2 + %g", lc_fault);
+//Field[2].F = Sprintf("0.02*F1 +(F1/2e3)^2 + %g", lc_fault);
+Field[2].F = Sprintf("0.05*F1 +(F1/2.5e3)^2 + %g", lc_fault);
+
+// Managing coarsening around the nucleation Patch
+Field[3] = Distance;
+Field[3].FacesList = {201};
+
+Field[4] = Threshold;
+Field[4].IField = 3;
+Field[4].LcMin = lc_nucl;
+Field[4].LcMax = lc_fault;
+Field[4].DistMin = R_nucl;
+Field[4].DistMax = 3*R_nucl;
+
+Field[5] = Restrict;
+Field[5].IField = 4;
+Field[5].FacesList = {100,200};
+
+// Equivalent of propagation size on element
+Field[6] = Threshold;
+Field[6].IField = 1;
+Field[6].LcMin = lc_fault;
+Field[6].LcMax = lc;
+Field[6].DistMin = 2*lc_fault;
+Field[6].DistMax = 2*lc_fault+0.001;
+
+
+Field[7] = Min;
+Field[7].FieldsList = {2,5,6};
+
+Background Field = 7;
+
+Physical Surface(101) = {1};
+Physical Surface(103) = {100,200};
+// This ones are read from the gui
+Physical Surface(105) = {14,18,22,26,27};
+
+Physical Volume(1) = {1};
+Mesh.MshFileVersion = 2.2;


### PR DESCRIPTION
The fault in the TPV104 example is larger than the one in TPV5 (36 instead of 30 km width). Also, the boxcar function for the velocity-strengthening layer in z direction was wrong.